### PR TITLE
Docs/add writeup tool guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,72 @@
 
     ```
 - writeupを書く際に必要になった画像ファイルなどは， `assets` ディレクトリに置きましょう．
+
+## テンプレート作成ツール
+
+このリポジトリには、CTFのWriteup用ディレクトリとファイルを自動生成するツール `writeup` が含まれています。
+
+### インストール方法
+
+1. `~/opt/bin` ディレクトリをPATHに追加します：
+   ```bash
+   # .bashrc または .zshrc に追加
+   export PATH="$HOME/opt/bin:$PATH"
+   ```
+
+2. シェルを再起動するか、設定ファイルを再読み込みします：
+   ```bash
+   source ~/.bashrc  # または source ~/.zshrc
+   ```
+
+3. ツールをインストールします：
+   ```bash
+   cd utils
+   make
+   ```
+
+### 使い方
+
+#### 1. CTFイベント用ディレクトリの初期化
+
+```bash
+writeup init GENRE/EVENT_NAME
+```
+
+- `GENRE`: `crypto`, `forensics`, `misc`, `osint`, `pwn`, `reversing`, `web` のいずれか
+- `EVENT_NAME`: CTFイベント名（例: `hoge_CTF_2023`）
+
+例：
+```bash
+writeup init crypto/hoge_CTF_2023
+```
+
+#### 2. 問題用テンプレートの生成
+
+```bash
+cd GENRE/EVENT_NAME
+writeup add CHALLENGE_NAME
+```
+
+例：
+```bash
+cd crypto/hoge_CTF_2023
+writeup add My_Question1
+```
+
+このコマンドにより、以下の構造が自動生成されます：
+```
+My_Question1/
+├── README.md          # 問題の概要とSolutionへのリンク
+├── given_files/       # 問題ファイル置き場
+├── assets/           # Writeup用画像ファイル置き場
+└── solve/
+    └── writeup.md    # 解法の詳細
+```
+
+### アンインストール
+
+```bash
+cd utils
+make clean
+```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 2. シェルを再起動するか、設定ファイルを再読み込みします：
    ```bash
-   source ~/.bashrc  # または source ~/.zshrc
+   source ~/.bashrc
    ```
 
 3. ツールをインストールします：

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -1,11 +1,16 @@
-all: writeup
+TARGET_DIR := $$HOME/opt/bin
+TARGET_BIN := writeup
 
-writeup: writeup.sh
-	@if echo $$PATH | grep -q $$HOME/opt/bin; then \
-		install $< $$HOME/opt/bin/$@; \
-    else \
-        echo '~/opt/binを$$PATHに追加してください。'; \
+all: $(TARGET_BIN)
+
+$(TARGET_BIN): writeup.sh
+	@if echo $$PATH | grep -q $(TARGET_DIR); then \
+		mkdir -p $(TARGET_DIR); \
+		ln -sf $$PWD/$< $(TARGET_DIR)/$@; \
+		chmod +x $(TARGET_DIR)/$@; \
+	else \
+		echo $(TARGET_DIR)を'$$PATH'に追加してください。; \
 	fi
 
 clean:
-	rm $$HOME/opt/bin/writeup
+	rm $$HOME/opt/bin/$(TARGET_BIN)


### PR DESCRIPTION
 ## 概要
  @tm99hjkl が作成してくれたテンプレート作成ツール(`writeup`)のインストール方法と使用方法をREADME.mdに追加しました。

  ## 変更内容
  - インストール手順（PATH設定、makeコマンド実行）
  - 使用方法（init, addコマンドの説明と例）
  - アンインストール方法
  - 自動生成されるディレクトリ構造の説明
  
  with Claude Code